### PR TITLE
Adding FSC calculation

### DIFF
--- a/cmtip/phasing/maps.py
+++ b/cmtip/phasing/maps.py
@@ -2,6 +2,8 @@ import numpy as np
 import mrcfile, h5py
 import skopi as sk
 import scipy.ndimage
+import scipy.interpolate
+from cmtip.alignment import errors
 
 """
 Functions for visualizing results of phasing and comparing to reference.
@@ -25,57 +27,34 @@ def save_mrc(savename, data, voxel_size=None):
     return
 
 
-def _retrieve_det_info(h5_file):
+def get_reciprocal_mesh(voxel_number_1d, distance_reciprocal_max):
     """
-    Retrieve the detector information from an input h5 file, assuming a
-    SimpleSquare Detector type.
-
-    :param h5_file: h5 file, with detector information stored as attributes
-    :return det_info: tuple of (n_pixels, det_size, det_distance) 
-    """
-    with h5py.File(h5_file, 'r') as f:
-        try:
-            n_pixels = f.attrs['n_pixels']
-        except:
-            n_pixels = int(np.sqrt(f.attrs['n_pixels_per_image']))
-        det_size = f.attrs['det_size']
-        det_distance = f.attrs['det_distance']
+    Get a centered, symetric mesh of given dimensions. 
+    Altered from skopi.
     
-    det_info = (n_pixels, det_size, det_distance)
-    return det_info
-
-
-def _setup_detector(det_info, beam_file):
+    :param voxel_number_1d: number of voxel per axis
+    :param distance_reciprocal_max: corner resolution of autocorrelation
+    :return reciprocal_mesh: grid of reciprocal distances with max edge 
+       resolution of distance_reciprocal_max
     """
-    Set up SimpleSquare detector.
+    max_value = distance_reciprocal_max
+    linspace = np.linspace(-max_value, max_value, voxel_number_1d)
+    reciprocal_mesh_stack = np.asarray(
+        np.meshgrid(linspace, linspace, linspace, indexing='ij'))
+    reciprocal_mesh = np.moveaxis(reciprocal_mesh_stack, 0, -1)
 
-    :param det_info: h5 file or tuple of (n_pixels, det_size, det_distance) 
-    :param beam_file: path to beam file 
-    :return det: instance of skopi's SimpleSquare Detector
-    """    
-    # set up Beam object
-    beam = sk.Beam(beam_file)
-
-    # instantiate Detector
-    if type(det_info) is not tuple:
-        det_info = _retrieve_det_info(det_info)
-    det = sk.SimpleSquareDetector(int(det_info[0]), 
-                                  float(det_info[1]), 
-                                  float(det_info[2]), 
-                                  beam=beam) 
-    return det
+    return reciprocal_mesh
     
 
-def compute_reference(pdb_file, det_info, beam_file, M):
+def compute_reference(pdb_file, M, distance_reciprocal_max):
     """
     Compute reference autocorrelation and density maps to the resolution
     limit dictated by the detector settings. Currently a SimpleSquare
     detector is assumed.
-
+    
     :param pdb_file: path to coordinates file
-    :param det_info: h5 file or tuple of (n_pixels, det_size, det_distance)
-    :param beam_file: path to beam file
     :param M: grid spacing
+    :param distance_reciprocal_max: corner resolution in meters
     :return ac: (M,M,M) array of the reference autocorrelation 
     :return density: (M,M,M) array of the reference density map
     """
@@ -86,8 +65,7 @@ def compute_reference(pdb_file, det_info, beam_file, M):
     particle.read_pdb(pdb_file, ff='WK')
 
     # compute ideal diffraction volume
-    det = _setup_detector(det_info, beam_file)
-    mesh, voxel_length = det.get_reciprocal_mesh(M)
+    mesh = get_reciprocal_mesh(M, distance_reciprocal_max)
     cfield = pg.calculate_diffraction_pattern_gpu(mesh, particle, return_type='complex_field')
     ivol = np.square(np.abs(cfield))
 
@@ -96,6 +74,141 @@ def compute_reference(pdb_file, det_info, beam_file, M):
     density = np.fft.fftshift(np.fft.ifftn(np.fft.ifftshift(cfield))).real
 
     return ac, density
+    
+
+def rotate_volume(volume, R):
+    """
+    Rotate input volume. Code from: https://www.javaer101.com/es/article/50982769.html.
+    
+    :param volume: input volume
+    :param R: rotation matrix
+    :return volumeR: rotated input volume
+    """
+
+    # create meshgrid
+    dim = volume.shape
+    ax = np.arange(dim[0])
+    ay = np.arange(dim[1])
+    az = np.arange(dim[2])
+    coords = np.meshgrid(ax, ay, az)
+
+    # stack the meshgrid to position vectors, center them around 0 by substracting dim/2
+    xyz = np.vstack([coords[0].reshape(-1) - float(dim[0]) / 2,  # x coordinate, centered
+                     coords[1].reshape(-1) - float(dim[1]) / 2,  # y coordinate, centered
+                     coords[2].reshape(-1) - float(dim[2]) / 2])  # z coordinate, centered
+
+    # apply transformation
+    transformed_xyz = np.dot(R, xyz)
+
+    # extract coordinates
+    x = transformed_xyz[0, :] + float(dim[0]) / 2
+    y = transformed_xyz[1, :] + float(dim[1]) / 2
+    z = transformed_xyz[2, :] + float(dim[2]) / 2
+
+    x = x.reshape((dim[1],dim[0],dim[2]))
+    y = y.reshape((dim[1],dim[0],dim[2]))
+    z = z.reshape((dim[1],dim[0],dim[2])) # reason for strange ordering: see next line
+
+    # the coordinate system seems to be strange, it has to be ordered like this
+    new_xyz = [y, x, z]
+
+    # sample
+    volumeR = scipy.ndimage.map_coordinates(volume, new_xyz, order=1)
+    
+    return volumeR
+
+
+def score_orientations(ref_volume, volume, orientations):
+    """
+    Score a set of quaternions to find the one that best rotates the target onto the 
+    reference volume.
+    
+    :param ref_volume: reference volume
+    :param volume: target volume
+    :param orientations: array of quaternions
+    :return quat: quaternions that best rotates volume onto ref_volume
+    """
+    ccs = np.zeros(len(orientations))
+    for i,q in enumerate(orientations):
+        R = sk.quaternion2rot3d(q)
+        r_volume = rotate_volume(volume, R)
+        ccs[i] = np.corrcoef(r_volume.flatten(), ref_volume.flatten())[0,1]
+    
+    index = np.argmax(ccs)
+    print(f"Index {index} has maximum CC score of {np.max(ccs)}")
+    
+    return orientations[index]
+
+
+def align_volumes(ref_volume, volume, sigma=0, n_iterations=10, tol=0.05):
+    """
+    Align volume to ref_volume. Candidate orientations are scored by computing
+    the cross-correlation between Gaussian-filtered versions of the volumes.
+    
+    :param ref_volume: reference volume
+    :param volume: target volume
+    :param sigma: sigma for Gaussian-filtering during alignment
+    :param n_iterations: maximum number of iterations
+    :param tol: convergence error in degrees (between iterations)
+    :return r_volume: rotated volume
+    """
+    
+    ref_volume_f = scipy.ndimage.gaussian_filter(ref_volume, sigma=sigma)
+    volume_f = scipy.ndimage.gaussian_filter(volume, sigma=sigma)
+    
+    quats = np.zeros((n_iterations,4))
+    orientations = sk.get_uniform_quat(720)
+    quats[0] = score_orientations(ref_volume_f, volume_f, orientations)
+    
+    for n in range(1,n_iterations):
+        orientations = sk.get_preferred_orientation_quat(1.0/n, 360, base_quat=quats[n-1])
+        orientations = np.vstack((quats[n-1], orientations))
+        quats[n] = score_orientations(ref_volume_f, volume_f, orientations)
+        if errors.alignment_error(np.array(quats[n-1]), np.array(quats[n])) < tol:
+            quats = quats[:n]
+            break
+        
+    r_volume = rotate_volume(volume, sk.quaternion2rot3d(quats[-1]))
+    return r_volume
+
+
+def compute_fsc(volume1, volume2, distance_reciprocal_max, spacing):
+    """
+    Compute the FSC curve.
+    
+    :param volume1: first volume
+    :param volume2: second volume
+    :param distance_reciprocal_max: corner resolution
+    :param spacing: spacing in per Angstrom for computing the FSC
+    :return rshell: reciprocal space radius in per Angstrom
+    :return fsc: fourier shell correlation values
+    :return resolution: estimated resolution based on FSC=0.5 in Angstrom
+    """
+    
+    mesh = get_reciprocal_mesh(volume1.shape[0], distance_reciprocal_max)
+    smags = np.linalg.norm(mesh, axis=-1).flatten() * 1e-10
+    r_spacings = np.arange(0, smags.max() / np.sqrt(3), spacing)
+    
+    ft1 = np.fft.fftshift(np.fft.fftn(volume1)).flatten()
+    ft2 = np.conjugate(np.fft.fftshift(np.fft.fftn(volume2)).flatten())
+    rshell, fsc = np.zeros(len(r_spacings)), np.zeros(len(r_spacings))
+    
+    for i,r in enumerate(r_spacings):
+        indices = np.where((smags>r) & (smags<r+spacing))[0]
+        numerator = np.sum(ft1[indices] * ft2[indices])
+        denominator = np.sqrt(np.sum(np.square(np.abs(ft1[indices]))) * np.sum(np.square(np.abs(ft2[indices]))))
+        rshell[i] = r + 0.5*spacing 
+        fsc[i] = numerator.real / denominator
+        
+    f = scipy.interpolate.interp1d(fsc, rshell)
+    try:
+        resolution = 1.0/f(0.5)
+        print("Estimated resolution from FSC: %.2f Angstrom" %(resolution))
+    except ValueError:
+        resolution = -1
+        print("Resolution could not be estimated.")
+        
+    return rshell, fsc, resolution
     
 
 def invert_handedness(density, output=None):

--- a/cmtip/reconstruct_mpi.py
+++ b/cmtip/reconstruct_mpi.py
@@ -116,8 +116,9 @@ def run_mtip_mpi(comm, data, M, output, aligned=True, n_iterations=10, res_limit
 
         # if M or resolution has changed, resize the support_ and rho_ from previous iteration
         if (M[generation] != M[generation-1]) or (res_limit_ac[generation] != res_limit_ac[generation-1]):
-            support_, rho_ = phaser.resize_mpi(comm, support_, rho_, M[generation], 
-                                               reciprocal_extents[generation-1], reciprocal_extents[generation])
+            support_, rho_ = None, None
+#            support_, rho_ = phaser.resize_mpi(comm, support_, rho_, M[generation], 
+#                                               reciprocal_extents[generation-1], reciprocal_extents[generation])
 
         # solve for autocorrelation
         ac = autocorrelation.solve_ac_mpi(comm,

--- a/cmtip/tests/test_align.py
+++ b/cmtip/tests/test_align.py
@@ -20,7 +20,9 @@ class TestAlignment(object):
         args['pdb_file'] = os.path.join(os.path.dirname(__file__), '../../examples/input/3iyf.pdb')
         args['det_info'] = ("128", "0.08", "0.2")
         args['n_images'] = 3
-        
+        args['increase_factor'] = 1
+        args['quantize'] = False
+
         cls.data = simulate_images(args)
         ivol = np.square(np.abs(cls.data['volume']))
         cls.ac = np.fft.fftshift(np.abs(np.fft.ifftn(ivol))).astype(np.float32)

--- a/cmtip/tests/test_errors.py
+++ b/cmtip/tests/test_errors.py
@@ -1,5 +1,11 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 from cmtip.alignment import errors
+from cmtip.phasing import *
 import numpy as np
+import skopi as sk
+import os
 
 def test_alignment_error():
     """ Check that calculation of rotation between quaternions is correct. """
@@ -19,3 +25,55 @@ def test_alignment_error():
         assert errors.alignment_error(quat1, q) == 180
     for q in [quatx90,quaty90,quatz90]:
         assert errors.alignment_error(quat1, q) == 90
+
+
+class TestMapsFunctions(object):
+    """
+    Test the phasing algorithm starting from the ideal autocorrelation.
+    In this case, different handedness will be indistinguishable in projection.
+    """
+    
+    @classmethod
+    def setup_class(cls):
+        
+        args = dict()
+        args['beam_file'] = os.path.join(os.path.dirname(__file__), '../../examples/input/amo86615.beam')
+        args['pdb_file'] = os.path.join(os.path.dirname(__file__), '../../examples/input/3iyf.pdb')
+        args['resolution'] = 9.0 # in Angstrom
+        args['M'] = 81 
+        args['spacing'] = 0.01
+        
+        ref_ac, cls.ref_density = compute_reference(args['pdb_file'], args['M'], 1e10/args['resolution'])
+        cls.args = args
+
+    def test_rotate_volume(self):
+        """ Check that volume rotation works. """
+
+        q_tar = sk.get_random_quat(1)[0]
+        tar_density = rotate_volume(self.ref_density, np.linalg.inv(sk.quaternion2rot3d(q_tar)))
+        inv_density = rotate_volume(tar_density, sk.quaternion2rot3d(q_tar))
+        assert np.corrcoef(self.ref_density.flatten(), inv_density.flatten())[0,1] > 0.85
+
+        f, ((ax1,ax2,ax3)) = plt.subplots(1, 3, figsize=(9,3))
+        hs = int(self.args['M']/2)
+
+        ax1.imshow(self.ref_density[hs,:,:])
+        ax2.imshow(tar_density[hs,:,:])
+        ax3.imshow(inv_density[hs,:,:])
+        
+        ax1.set_title("Reference", fontsize=12)
+        ax2.set_title("Rotated", fontsize=12)
+        ax3.set_title("Unrotated", fontsize=12)
+
+        f.savefig("test_rotate_volume.png", dpi=300, bbox_inches='tight')
+
+    def test_compute_fsc(self):
+        """ Check volume alignment and FSC calculation. """
+
+        q_tar = sk.get_random_quat(1)[0]
+        tar_density = rotate_volume(self.ref_density, np.linalg.inv(sk.quaternion2rot3d(q_tar)))
+        inv_density = rotate_volume(tar_density, sk.quaternion2rot3d(q_tar))
+        
+        rs, fsc, res = compute_fsc(self.ref_density, inv_density, 1e10/self.args['resolution'], self.args['spacing'])
+        assert res < self.args['resolution']*1.25
+

--- a/cmtip/tests/test_nufft.py
+++ b/cmtip/tests/test_nufft.py
@@ -20,6 +20,8 @@ class TestNUFFT(object):
         args['pdb_file'] = os.path.join(os.path.dirname(__file__), '../../examples/input/3iyf.pdb')
         args['det_info'] = ("128", "0.08", "0.2")
         args['n_images'] = 1
+        args['increase_factor'] = 1
+        args['quantize'] = False
         
         data = simulate_images(args)
         cls.ivol = np.square(np.abs(data['volume'].astype(np.float32))) * 1e-6

--- a/cmtip/tests/test_phasing.py
+++ b/cmtip/tests/test_phasing.py
@@ -21,10 +21,10 @@ class TestPhase(object):
         args = dict()
         args['beam_file'] = os.path.join(os.path.dirname(__file__), '../../examples/input/amo86615.beam')
         args['pdb_file'] = os.path.join(os.path.dirname(__file__), '../../examples/input/3iyf.pdb')
-        args['det_info'] = (128, 0.08, 0.2)
+        args['resolution'] = 10.0 # in Angstrom
         args['M'] = 81 
         
-        ref_ac, ref_density = compute_reference(args['pdb_file'], args['det_info'], args['beam_file'], args['M'])
+        ref_ac, ref_density = compute_reference(args['pdb_file'], args['M'], 1e10/args['resolution'])
         cls.ref_density = gaussian_filter(ref_density, sigma=0.8) # reference will have higher res than phased
         ac_phased, support_, rho_ = phase(0, ref_ac, nER=60, nHIO=30)
         cls.est_density = np.fft.ifftshift(rho_)
@@ -39,11 +39,11 @@ class TestPhase(object):
                     est_proj = np.sum(self.est_density, axis=j)
                     cc_proj = np.corrcoef(ref_proj.flatten(), est_proj.flatten())[0,1]
                     if i == j: # corresponding slices match
-                        assert cc_proj > 0.9
+                        assert cc_proj > 0.85
                     elif i!=2 and j!=2: # additional matches due to this protein's symmetry
-                        assert cc_proj > 0.9
+                        assert cc_proj > 0.85
                     else:
-                        assert cc_proj < 0.9
+                        assert cc_proj < 0.85
                         
         f, ((ax1,ax2,ax3), (ax4,ax5,ax6)) = plt.subplots(2, 3, figsize=(9,6))
 

--- a/examples/compute_fsc.py
+++ b/examples/compute_fsc.py
@@ -1,0 +1,78 @@
+import numpy as np
+import time, os, argparse
+import glob, mrcfile
+from cmtip.phasing import *
+
+"""
+Compute FSC for a set of MTIP solutions by comparison to the reference density. For 
+each density map, both the solution and its inversion (due to handedness ambiguity) 
+are tested, and the higher resolution score is kept.
+"""
+
+def parse_input():
+    """
+    Parse command line input.
+    """
+    parser = argparse.ArgumentParser(description="Compute FSC relative to refrence from a series of MRC files.")
+    parser.add_argument('-i', '--input', help='Input PDB files in glob-readable format', required=True, type=str)
+    parser.add_argument('-o', '--output', help='Output for saving resolutions array', required=True, type=str)
+    parser.add_argument('-p', '--pdb_file', help='PDB file of reference structure', required=True, type=str)
+    parser.add_argument('-m', '--M', help='Cubic length of reconstruction volume', required=True, type=int)
+    parser.add_argument('-r', '--resolution', help='Corner resolution of autocorrelation', required=True, type=float)
+    parser.add_argument('-s', '--sigma', help='Sigma for Gaussian-filtering volumes prior to alignment', required=True, type=float)
+    parser.add_argument('-d', '--spacing', help='d-spacing of FSC curve in per Angstrom', required=False, default=0.01, type=float)
+
+    return vars(parser.parse_args())
+
+
+def calculate_res(ref_density, est_density, sigma, max_res, spacing, n_iterations=10, tol=0.01):
+    """
+    Estimate resolution of the estimated density by aligning it to the reference density
+    and determining where the FSC between the aligned volumes falls to 0.5.
+
+    :param ref_density: reference density map
+    :param est_density: estimated density map, same dimensions as ref_density
+    :param sigma: sigma by which to Gaussian filter volumes during alignment
+    :param max_res: corner resolution of AC from which est_density was derived in Angstrom
+    :param spacing: d-spacing for computing the FSC curve in per Ansgtrom
+    :param n_iteration: max number of alignment iterations, default=10
+    :param tol: tolerance in degrees for determining when alignment has converged, default=0.01
+    :return est_res: estimated resolution based on FSC=0.5 in Angstrom
+    """
+    rot_density = align_volumes(ref_density, est_density, 
+                                sigma=sigma, n_iterations=n_iterations, tol=tol)
+    rs, fsc, est_res = compute_fsc(ref_density, rot_density, 1e10/max_res, spacing)
+
+    return est_res
+
+
+def main():
+    
+    # retrieve command line and compute reference
+    args = parse_input()
+    ref_ac, ref_density = compute_reference(args['pdb_file'], args['M'], 1e10/args['resolution'])
+
+    # retrieve filenames, set up resolution array to be saved
+    fnames = glob.glob(args['input'])
+    resolutions = np.zeros(len(fnames))
+
+    for i,fn in enumerate(fnames):
+        solution = mrcfile.open(fn).data
+        res1 = calculate_res(ref_density, solution, args['sigma'], args['resolution'], args['spacing'])
+
+        # check inverted density map
+        solution = invert_handedness(fn)
+        res2 = calculate_res(ref_density, solution, args['sigma'], args['resolution'], args['spacing'])
+
+        resolutions[i] = np.min(np.array([res1, res2]))
+
+    print(f"No. density maps: {len(fnames)}")
+    print(f"mean resolution: {np.mean(resolutions):.2f}")
+    print(f"min. resolution: {np.min(resolutions):.2f}")
+
+    np.save(args['output'], resolutions)
+    return
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Functions are added to enable estimating the resolution by aligning the reference structure and MTIP solution and then computing the FSC between the aligned volumes. The simulation script has also been updated to optionally simulate photons (with a command-line adjusted increase in fluence) rather than (noise-free) intensities.