### PR TITLE
Optionally batch model slices during alignment

### DIFF
--- a/cmtip/autocorrelation/autocorrelation_mpi.py
+++ b/cmtip/autocorrelation/autocorrelation_mpi.py
@@ -126,7 +126,8 @@ def solve_ac_mpi(comm, generation, pixel_position_reciprocal, reciprocal_extent,
 
     alambda = 1
     #rlambda = Mtot / N / 1000
-    rlambda = Mtot/(N*comm.size) * 2**(comm.rank - comm.size/2)
+    #rlambda = Mtot/(N*comm.size) * 2**(comm.rank - comm.size/2)
+    rlambda = Mtot/N * 2**(comm.rank - comm.size/2)
     #flambda = 1e3
     flambda = 1e5 * pow(10, comm.rank - comm.size//2)
     maxiter = 100

--- a/cmtip/reconstruct_mpi.py
+++ b/cmtip/reconstruct_mpi.py
@@ -17,21 +17,21 @@ def parse_input():
     """
     parser = argparse.ArgumentParser(description="Reconstruct an SPI dataset using the MTIP algorithm with MPI parallelization.")
     parser.add_argument('-i', '--input', help='Input h5 file containing intensities and exp information.')
-    parser.add_argument('-m', '--M', help='Cubic length of reconstruction volume', required=True, nargs='+', type=int)
+    parser.add_argument('-m', '--M', help='Cubic length of reconstruction volume at each resolution', required=True, nargs='+', type=int)
     parser.add_argument('-o', '--output', help='Path to output directory', required=True, type=str)
     parser.add_argument('-t', '--n_images', help='Total number of images to process', required=True, type=int)
-    parser.add_argument('-n', '--niter', help='Number of MTIP iterations', required=False, type=int, default=10)
+    parser.add_argument('-n', '--niter', help='Number of MTIP iterations at each resolution/size', required=False, type=int, default=10)
     parser.add_argument('-r', '--res_limit_ac', help='Resolution limit for solving AC at each iteration, overrides niter', 
                         required=False, nargs='+', type=float)
     parser.add_argument('-b', '--bin_factor', help='Factor by which to bin data', required=False, type=int, default=1)
-    parser.add_argument('-ap', '--a_params', help='Alignment parameters: (n_reference, res_limit, weighting_order)',
-                        required=False, nargs=3, type=float, default=[2500, 8.0, -2])
+    parser.add_argument('-ap', '--a_params', help='Alignment parameters: (n_reference, res_limit, weighting_order, nbatches)',
+                        required=False, nargs=4, type=float, default=[2500, 8.0, -2, 1])
     parser.add_argument('-a', '--aligned', help='Alignment from reference quaternions', action='store_true')
 
     return vars(parser.parse_args())
 
 
-def run_mtip_mpi(comm, data, M, output, aligned=True, n_iterations=10, res_limit_ac=None, a_params=[2500,8,-2]):
+def run_mtip_mpi(comm, data, M, output, aligned=True, n_iterations=10, res_limit_ac=None, a_params=[2500,8,-2,1]):
     """
     Run MTIP algorithm.
     
@@ -42,7 +42,7 @@ def run_mtip_mpi(comm, data, M, output, aligned=True, n_iterations=10, res_limit
     :param aligned: if False use ground truth quaternions
     :param n_iterations: number of MTIP iterations to run, default=10
     :param res_limit_ac: resolution limit to which to solve AC at each iteration. if None use full res.
-    :param a_params: list of alignment parameters, (n_reference, res_limit, weight_order)
+    :param a_params: list of alignment parameters, (n_reference, res_limit, weight_order, nbatches)
     """  
     print("Running MTIP")
     start_time = time.time()
@@ -52,7 +52,7 @@ def run_mtip_mpi(comm, data, M, output, aligned=True, n_iterations=10, res_limit
     if res_limit_ac is None:
         res_limit_ac = np.zeros(n_iterations)
     reciprocal_extents = np.zeros(n_iterations)
-    n_ref, res_limit_align, weight_order = int(a_params[0]), a_params[1], a_params[2]
+    n_ref, res_limit_align, weight_order, nbatches = int(a_params[0]), a_params[1], a_params[2], int(a_params[3])
 
     # iteration 0: ac_estimate is unknown
     generation = 0
@@ -99,6 +99,7 @@ def run_mtip_mpi(comm, data, M, output, aligned=True, n_iterations=10, res_limit
                                                         intensities,
                                                         ac_phased.astype(np.float32),
                                                         n_ref,
+                                                        nbatches=nbatches,
                                                         order=weight_order)
         else:
             print("Using ground truth quaternions")
@@ -114,11 +115,9 @@ def run_mtip_mpi(comm, data, M, output, aligned=True, n_iterations=10, res_limit
         reciprocal_extents[generation] = reciprocal_extent
         print(f"Iteration {generation}: trimmed data to {1e10/reciprocal_extent} A resolution")
 
-        # if M or resolution has changed, resize the support_ and rho_ from previous iteration
+        # if M or resolution has changed, do not use support_ and rho_ from previous iteration
         if (M[generation] != M[generation-1]) or (res_limit_ac[generation] != res_limit_ac[generation-1]):
             support_, rho_ = None, None
-#            support_, rho_ = phaser.resize_mpi(comm, support_, rho_, M[generation], 
-#                                               reciprocal_extents[generation-1], reciprocal_extents[generation])
 
         # solve for autocorrelation
         ac = autocorrelation.solve_ac_mpi(comm,
@@ -152,13 +151,11 @@ def main():
     n_images_batch = int(args['n_images'] / size)
     
     # set resolution and volume size at each iteration
-    if args['res_limit_ac'] is not None:
-        args['niter'] = len(args['res_limit_ac'])
-    if len(args['M']) == 1:
-        args['M'] = args['niter'] * args['M']
-    if len(args['M']) != args['niter']:
-        print("Error: M array does not match number of MTIP iterations")
+    if len(args['M']) != len(args['res_limit_ac']):
+        print("Error: lengths of res_limit_ac and M input must match.")
         sys.exit()
+    args['M'] = np.repeat(np.array(args['M']), args['niter'])
+    args['res_limit_ac'] = np.repeat(np.array(args['res_limit_ac']), args['niter'])
 
     # load subset of data onto each rank and bin if requested
     data = load_h5(args['input'], start=rank*n_images_batch, end=(rank+1)*n_images_batch)
@@ -171,7 +168,7 @@ def main():
 
     # run MTIP to reconstruct density from simulated diffraction images
     run_mtip_mpi(comm, data, args['M'], args['output'], aligned=args['aligned'], 
-                 n_iterations=args['niter'], res_limit_ac=args['res_limit_ac'], a_params=args['a_params'])
+                 n_iterations=len(args['M']), res_limit_ac=args['res_limit_ac'], a_params=args['a_params'])
 
 
 if __name__ == '__main__':

--- a/cmtip/tests/test_align.py
+++ b/cmtip/tests/test_align.py
@@ -38,6 +38,7 @@ class TestAlignment(object):
                                              self.data['intensities'],
                                              self.ac,
                                              100,
+                                             nbatches=2,
                                              true_orientations=self.data['orientations'])
     
         assert np.all(quats - self.data['orientations'])==0


### PR DESCRIPTION
The alignment calculation is updated to enable batching the model slices during alignment, since increasing the number of model slices taken through the autocorrelation was found to benefit recovery of high-resolution information. Two additional changes were made: 1) the command line input for reconstruct_mpi.py was updated so that n iterations is performed at each res_limit_ac/M pairing, and 2) one of the lambdas for the ac solver was changed to match spinifel (though this doesn't seem to affect reconstruction).