### PR TITLE
remove dependency on cuda optional

### DIFF
--- a/cmtip/nufft/adjoint.py
+++ b/cmtip/nufft/adjoint.py
@@ -1,5 +1,4 @@
 import numpy as np
-from cufinufft import cufinufft
 import finufft as nfft 
 
 
@@ -60,7 +59,8 @@ def adjoint_gpu(nuvect, H_, K_, L_, M, use_recip_sym=True, support=None):
     """
     
     from pycuda.gpuarray import GPUArray, to_gpu
-    import pycuda.autoinit
+    import pycuda.autoinit    
+    from cufinufft import cufinufft
     
     # make sure that points lie within permissible finufft domain
     assert np.max(np.abs(np.array([H_, K_, L_]))) < 3*np.pi

--- a/cmtip/nufft/forward.py
+++ b/cmtip/nufft/forward.py
@@ -1,5 +1,4 @@
 import numpy as np
-from cufinufft import cufinufft
 import finufft as nfft 
 
 
@@ -58,6 +57,7 @@ def forward_gpu(ugrid, H_, K_, L_, support=None, use_recip_sym=True):
     
     from pycuda.gpuarray import GPUArray, to_gpu
     import pycuda.autoinit
+    from cufinufft import cufinufft
     
     # make sure that points lie within permissible finufft domain
     assert np.max(np.abs(np.array([H_, K_, L_]))) < 3*np.pi

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ requirements = [
     'mrcfile',
     'skopi',
     'finufft',
-    'cufinufft',
     'matplotlib',
     'setuptools'
 ]
@@ -29,4 +28,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
+    extras_require={
+        "gpu": ["cufinufft", "pycuda"],
+    },
     zip_safe=False)


### PR DESCRIPTION
this should allow users to run cmtip without needing to install cufinufft + pycuda