### PR TITLE
Checkpoint each iteration

### DIFF
--- a/cmtip/prep_data.py
+++ b/cmtip/prep_data.py
@@ -294,18 +294,22 @@ def save_checkpoint(generation, output, checkpoint):
     return
 
 
-def load_checkpoint(input_file=None):
+def load_checkpoint(input_file=None, rank=None):
     """
     Load an intermediate checkpoint file or provide default values if 
     no checkpoint file is supplied.
     
     :param input_file: path to h5 checkpoint file
+    :param rank: rank of current node; None if in sequential mode
     :return checkpoint: dictionary containing output from an MTIP iteration
     """
     checkpoint = dict()
     if input_file is None:
         checkpoint['generation'] = 0
-        checkpoint['orientations'] = None
+        if rank is None:
+            checkpoint['orientations'] = None
+        else:
+            checkpoint[f'orientations_r{rank}'] = None
     else:
         with h5py.File(input_file, 'r') as f:
             checkpoint['generation'] = int(input_file.split("/")[-1].split("g")[1][:-3])

--- a/cmtip/reconstruct.py
+++ b/cmtip/reconstruct.py
@@ -57,6 +57,7 @@ def run_mtip(data, M, output, aligned=True, n_iterations=10, use_gpu=False, chec
                                       orientations=checkpoint['orientations'],
                                       use_gpu=use_gpu)
         checkpoint['ac_phased'], checkpoint['support_'], checkpoint['rho_'] = phaser.phase(checkpoint['generation'], ac)
+        checkpoint['reciprocal_extent'] = data['reciprocal_extent']
         save_checkpoint(0, output, checkpoint)
     
     # iterations 1-n_iterations: ac_estimate from phasing
@@ -76,7 +77,7 @@ def run_mtip(data, M, output, aligned=True, n_iterations=10, use_gpu=False, chec
                                                                       n_ref,
                                                                       use_gpu=use_gpu)
         # solve for autocorrelation
-        ac = autocorrelation.solve_ac(generation,
+        checkpoint['ac'] = autocorrelation.solve_ac(generation,
                                       data['pixel_position_reciprocal'],
                                       data['reciprocal_extent'],
                                       data['intensities'],
@@ -86,7 +87,7 @@ def run_mtip(data, M, output, aligned=True, n_iterations=10, use_gpu=False, chec
                                       ac_estimate=checkpoint['ac_phased'].astype(np.float32))
         # phase
         checkpoint['ac_phased'], checkpoint['support_'], checkpoint['rho_'] = phaser.phase(generation, 
-                                                                                           ac, 
+                                                                                           checkpoint['ac'], 
                                                                                            checkpoint['support_'], 
                                                                                            checkpoint['rho_'])
         save_checkpoint(generation, output, checkpoint)


### PR DESCRIPTION
Compile the output from each MTIP iteration (ac, ac_phased, orientations, rho_, support_) to 1. enable restarting MTIP from intermediate files rather than scratch and 2. help debug. For the former, reconstruction scripts are called with the `--cpt` flag, which takes as input the checkpoint file name. Note that in mpi mode, only orientations from rank 0 are currently saved (since this information is not used for an intermediate restart. For completeness, consider modifying the code to save orientations from all ranks at a later date.)