### PR TITLE
Fixed CUPY bug

### DIFF
--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -3,6 +3,8 @@ import numpy as np
 import skopi as sk
 import h5py
 
+from sk.util import asnumpy
+
 """
 Simulate a simple SPI dataset on either a SimpleSquare or LCLSDetector. Either intensities 
 (default) or photons (intensities+Poission noise) are computed, and then corrected for the
@@ -66,7 +68,6 @@ def setup_experiment(args):
     
     return exp
 
-
 def simulate_writeh5(args):
     """
     Simulate diffraction images and save to h5 file.
@@ -86,10 +87,10 @@ def simulate_writeh5(args):
     f = h5py.File(args["output"], "w")
 
     # store useful experiment arrays
-    f.create_dataset("pixel_position_reciprocal", data=np.moveaxis(exp.det.pixel_position_reciprocal, -1, 0)) # s-vectors in m-1 
-    f.create_dataset("volume", data=exp.volumes[0]) # reciprocal space volume, 151 pixels cubed
-    f.create_dataset("pixel_index_map", data=exp.det.pixel_index_map) # indexing map for reassembly
-    f.create_dataset("orientations", data=exp._orientations) # ground truth quaternions
+    f.create_dataset("pixel_position_reciprocal", data=np.moveaxis(asnumpy(exp.det.pixel_position_reciprocal, -1, 0))) # s-vectors in m-1
+    f.create_dataset("volume", data=asnumpy(exp.volumes[0])) # reciprocal space volume, 151 pixels cubed
+    f.create_dataset("pixel_index_map", data=asnumpy(exp.det.pixel_index_map)) # indexing map for reassembly
+    f.create_dataset("orientations", data=asnumpy(exp._orientations)) # ground truth quaternions
 
     # simulate images and save to h5 file
     imgs = f.create_dataset(itype, shape=((args['n_images'],) + exp.det.shape))
@@ -101,7 +102,7 @@ def simulate_writeh5(args):
         imgs[num,:,:,:] = img / exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
 
     # save useful attributes
-    f.attrs['reciprocal_extent'] = np.linalg.norm(exp.det.pixel_position_reciprocal, axis=-1).max() # max |s|
+    f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal, axis=-1)).max() # max |s|
     f.attrs['n_images'] = args['n_images'] # number of simulated shots
     f.attrs['n_pixels_per_image'] = exp.det.pixel_num_total # number of total pixels per image
     f.attrs['det_shape'] = exp.det.shape # detector shape (n_panels, panel_num_x, panel_num_y)
@@ -145,11 +146,11 @@ def simulate_images(args):
 
     # populate rest of dictionary
     data["orientations"] = exp._orientations # quaternions
-    data['reciprocal_extent'] = np.linalg.norm(exp.det.pixel_position_reciprocal, axis=-1).max() # max |s|
-    data['pixel_position_reciprocal'] = np.moveaxis(exp.det.pixel_position_reciprocal, -1, 0) # s-vectors in m-1
+    data['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal, axis=-1)).max() # max |s|
+    data['pixel_position_reciprocal'] = np.moveaxis(asnumpy(exp.det.pixel_position_reciprocal, -1, 0)) # s-vectors in m-1
     data['n_images'] = args['n_images'] # number of simulated shots
     data['n_pixels_per_image'] = exp.det.pixel_num_total # number of total pixels per image
-    data['volume'] = exp.volumes[0] # reciprocal space volume
+    data['volume'] = asnumpy(exp.volumes[0]) # reciprocal space volume
     data['pixel_index_map'] = exp.det.pixel_index_map # indexing map for reassembly
     data['det_shape'] = exp.det.shape # detector shape (n_panels, panel_num_x, panel_num_y)
 

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -96,9 +96,9 @@ def simulate_writeh5(args):
     imgs = f.create_dataset(itype, shape=((args['n_images'],) + exp.det.shape))
     for num in range(args['n_images']):
         if itype == 'intensities':
-            img = exp.generate_image_stack(return_intensities=True)
+            img = asnumpy(exp.generate_image_stack(return_intensities=True))
         else:
-            img = exp.generate_image_stack(return_photons=True)
+            img = asnumpy(exp.generate_image_stack(return_photons=True))
         imgs[num,:,:,:] = img / exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
 
     # save useful attributes

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -100,7 +100,7 @@ def simulate_writeh5(args):
         else:
             img = exp.generate_image_stack(return_photons=True)
         imgs[num,:,:,:] = asnumpy(img) #/ exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
-        imgs[num,:,:,:] /= exp.det.polarization_correction #/ exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
+        imgs[num,:,:,:] /= asnumpy(exp.det.polarization_correction) #/ exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
         imgs[num, :, :, :] /= exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
 
     # save useful attributes

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -87,7 +87,7 @@ def simulate_writeh5(args):
     f = h5py.File(args["output"], "w")
 
     # store useful experiment arrays
-    f.create_dataset("pixel_position_reciprocal", data=np.moveaxis(asnumpy(exp.det.pixel_position_reciprocal, -1, 0))) # s-vectors in m-1
+    f.create_dataset("pixel_position_reciprocal", data=np.moveaxis(asnumpy(exp.det.pixel_position_reciprocal), -1, 0)) # s-vectors in m-1
     f.create_dataset("volume", data=asnumpy(exp.volumes[0])) # reciprocal space volume, 151 pixels cubed
     f.create_dataset("pixel_index_map", data=asnumpy(exp.det.pixel_index_map)) # indexing map for reassembly
     f.create_dataset("orientations", data=asnumpy(exp._orientations)) # ground truth quaternions
@@ -102,7 +102,7 @@ def simulate_writeh5(args):
         imgs[num,:,:,:] = img / exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
 
     # save useful attributes
-    f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal, axis=-1)).max() # max |s|
+    f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal), axis=-1).max() # max |s|
     f.attrs['n_images'] = args['n_images'] # number of simulated shots
     f.attrs['n_pixels_per_image'] = exp.det.pixel_num_total # number of total pixels per image
     f.attrs['det_shape'] = exp.det.shape # detector shape (n_panels, panel_num_x, panel_num_y)
@@ -146,8 +146,8 @@ def simulate_images(args):
 
     # populate rest of dictionary
     data["orientations"] = exp._orientations # quaternions
-    data['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal, axis=-1)).max() # max |s|
-    data['pixel_position_reciprocal'] = np.moveaxis(asnumpy(exp.det.pixel_position_reciprocal, -1, 0)) # s-vectors in m-1
+    data['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal), axis=-1).max() # max |s|
+    data['pixel_position_reciprocal'] = np.moveaxis(asnumpy(exp.det.pixel_position_reciprocal), -1, 0) # s-vectors in m-1
     data['n_images'] = args['n_images'] # number of simulated shots
     data['n_pixels_per_image'] = exp.det.pixel_num_total # number of total pixels per image
     data['volume'] = asnumpy(exp.volumes[0]) # reciprocal space volume

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -3,7 +3,7 @@ import numpy as np
 import skopi as sk
 import h5py
 
-from sk.util import asnumpy
+from skopi.util import asnumpy
 
 """
 Simulate a simple SPI dataset on either a SimpleSquare or LCLSDetector. Either intensities 

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -99,7 +99,7 @@ def simulate_writeh5(args):
             img = exp.generate_image_stack(return_intensities=True)
         else:
             img = exp.generate_image_stack(return_photons=True)
-        imgs[num,:,:,:] = img #/ exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
+        imgs[num,:,:,:] = asnumpy(img) #/ exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
         imgs[num,:,:,:] /= exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
 
     # save useful attributes

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -96,10 +96,10 @@ def simulate_writeh5(args):
     imgs = f.create_dataset(itype, shape=((args['n_images'],) + exp.det.shape))
     for num in range(args['n_images']):
         if itype == 'intensities':
-            img = asnumpy(exp.generate_image_stack(return_intensities=True))
+            img = exp.generate_image_stack(return_intensities=True)
         else:
-            img = asnumpy(exp.generate_image_stack(return_photons=True))
-        imgs[num,:,:,:] = img / exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
+            img = exp.generate_image_stack(return_photons=True)
+        imgs[num,:,:,:] = img / asnumpy(exp.det.polarization_correction) / asnumpy(exp.det.solid_angle_per_pixel) / 1e6 # scale for nufft bounds
 
     # save useful attributes
     f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal), axis=-1).max() # max |s|

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -99,7 +99,7 @@ def simulate_writeh5(args):
             img = exp.generate_image_stack(return_intensities=True)
         else:
             img = exp.generate_image_stack(return_photons=True)
-        imgs[num,:,:,:] = img / asnumpy(exp.det.polarization_correction) / asnumpy(exp.det.solid_angle_per_pixel) / 1e6 # scale for nufft bounds
+        imgs[num,:,:,:] = img / exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
 
     # save useful attributes
     f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal), axis=-1).max() # max |s|

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -101,7 +101,7 @@ def simulate_writeh5(args):
             img = exp.generate_image_stack(return_photons=True)
         imgs[num,:,:,:] = asnumpy(img) #/ exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
         imgs[num,:,:,:] /= asnumpy(exp.det.polarization_correction) #/ exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
-        imgs[num, :, :, :] /= exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
+        imgs[num, :, :, :] /= asnumpy(exp.det.solid_angle_per_pixel) / 1e6 # scale for nufft bounds
 
     # save useful attributes
     f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal), axis=-1).max() # max |s|

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -99,9 +99,7 @@ def simulate_writeh5(args):
             img = exp.generate_image_stack(return_intensities=True)
         else:
             img = exp.generate_image_stack(return_photons=True)
-        imgs[num,:,:,:] = asnumpy(img) #/ exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
-        imgs[num,:,:,:] /= asnumpy(exp.det.polarization_correction) #/ exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
-        imgs[num, :, :, :] /= asnumpy(exp.det.solid_angle_per_pixel) / 1e6 # scale for nufft bounds
+        imgs[num,:,:,:] = asnumpy(img / exp.det.polarization_correction / exp.det.solid_angle_per_pixel) / 1e6 # scale for nufft bounds
 
     # save useful attributes
     f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal), axis=-1).max() # max |s|

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -99,7 +99,8 @@ def simulate_writeh5(args):
             img = exp.generate_image_stack(return_intensities=True)
         else:
             img = exp.generate_image_stack(return_photons=True)
-        imgs[num,:,:,:] = img / exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
+        imgs[num,:,:,:] = img #/ exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
+        imgs[num,:,:,:] /= exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
 
     # save useful attributes
     f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal), axis=-1).max() # max |s|

--- a/cmtip/simulate.py
+++ b/cmtip/simulate.py
@@ -100,7 +100,8 @@ def simulate_writeh5(args):
         else:
             img = exp.generate_image_stack(return_photons=True)
         imgs[num,:,:,:] = asnumpy(img) #/ exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
-        imgs[num,:,:,:] /= exp.det.polarization_correction / exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
+        imgs[num,:,:,:] /= exp.det.polarization_correction #/ exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
+        imgs[num, :, :, :] /= exp.det.solid_angle_per_pixel / 1e6 # scale for nufft bounds
 
     # save useful attributes
     f.attrs['reciprocal_extent'] = np.linalg.norm(asnumpy(exp.det.pixel_position_reciprocal), axis=-1).max() # max |s|


### PR DESCRIPTION
Closes #25. 

With `USE_CUPY=0`:
```bash
Simulating diffraction images
Simulated dataset saved to 2cexa_sim.h5
elapsed time is 1.32
```

With `USE_CUPY=1`:
```bash
Simulating diffraction images
Simulated dataset saved to 2cexa_sim.h5
elapsed time is 0.20
```